### PR TITLE
Add hasOptions(array) to Arguments concern.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         "php": ">=7.0",
         "artisansdk/contract": "dev-master",
         "artisansdk/event": "dev-master",
-        "illuminate/container": "~5.0 | ~6.0",
-        "illuminate/database": "~5.0 | ~6.0",
-        "illuminate/queue": "~5.0 | ~6.0",
-        "illuminate/support": "~5.0 | ~6.0",
+        "illuminate/container": "5.0 - 5.8 | ^6.0",
+        "illuminate/database": "5.0 - 5.8 | ^6.0",
+        "illuminate/queue": "5.0 - 5.8 | ^6.0",
+        "illuminate/support": "5.0 - 5.8 | ^6.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
         "artisansdk/bench": "dev-master",
-        "illuminate/cache": "~5.0 | ~6.0",
-        "illuminate/pagination": "~5.0 | ~6.0",
-        "illuminate/validation": "~5.0 | ~6.0"
+        "illuminate/cache": "5.0 - 5.8 | ^6.0",
+        "illuminate/pagination": "5.0 - 5.8 | ^6.0",
+        "illuminate/validation": "5.0 - 5.8 | ^6.0"
     },
     "suggest": {
         "illuminate/cache": "CQRS supports automatic caching and cache-busting of queries using Laravel's CacheManager class.",

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         "php": ">=7.0",
         "artisansdk/contract": "dev-master",
         "artisansdk/event": "dev-master",
-        "illuminate/container": "~5.0",
-        "illuminate/database": "~5.0",
-        "illuminate/queue": "~5.0",
-        "illuminate/support": "~5.0",
+        "illuminate/container": "~5.0 | ~6.0",
+        "illuminate/database": "~5.0 | ~6.0",
+        "illuminate/queue": "~5.0 | ~6.0",
+        "illuminate/support": "~5.0 | ~6.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
         "artisansdk/bench": "dev-master",
-        "illuminate/cache": "~5.0",
-        "illuminate/pagination": "~5.0",
-        "illuminate/validation": "~5.0"
+        "illuminate/cache": "~5.0 | ~6.0",
+        "illuminate/pagination": "~5.0 | ~6.0",
+        "illuminate/validation": "~5.0 | ~6.0"
     },
     "suggest": {
         "illuminate/cache": "CQRS supports automatic caching and cache-busting of queries using Laravel's CacheManager class.",

--- a/src/Concerns/Arguments.php
+++ b/src/Concerns/Arguments.php
@@ -101,6 +101,24 @@ trait Arguments
     }
 
     /**
+     * Does the class have all given options set?
+     * 
+     * @param array $names
+     * 
+     * @return bool
+     */
+    protected function hasOptions(array $names): bool
+    {
+        foreach ($names as $name) {
+            if (! $this->hasOption($name)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Resolve the default value from a primitive or a closure.
      *
      * @param string $name  of option


### PR DESCRIPTION
I found myself wanting to do something similar to Laravel's $request->has(['param1', 'param2']) and noticed Arguments::hasOption doesn't support arrays. Adding a plural method felt better than adding array handling to hasOption, but either works for my purposes.

I didn't see any tests for hasOption so I didn't add one for this function.