### PR TITLE
Update psr/log dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/database": "^5.0 | ^6.0 | ^7.0 | ^8.0",
         "illuminate/queue": "^5.0 | ^6.0 | ^7.0 | ^8.0",
         "illuminate/support": "^5.0 | ^6.0 | ^7.0 | ^8.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 | ^2.0"
     },
     "require-dev": {
         "artisansdk/bench": "dev-master",


### PR DESCRIPTION
It looks like a fresh install of laravel today locks on psr/log v2. This PR matches the psr/log dependency of laravel/framework.